### PR TITLE
feat: Implement pagination for articles and optimize configuration

### DIFF
--- a/service/article/src/main/java/article/controller/ArticleController.java
+++ b/service/article/src/main/java/article/controller/ArticleController.java
@@ -3,7 +3,10 @@ package article.controller;
 import article.controller.dto.request.ArticleCreateRequest;
 import article.controller.dto.request.ArticleUpdateRequest;
 import article.controller.dto.response.ArticleResponse;
+import article.controller.dto.response.ArticlesResponse;
+import article.service.dto.result.ArticleResults;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.repository.query.Param;
 import org.springframework.web.bind.annotation.*;
 import article.service.ArticleService;
 import article.service.dto.result.ArticleResult;
@@ -37,5 +40,13 @@ public class ArticleController {
     @DeleteMapping("/{articleId}")
     public void deleteArticle(@PathVariable(name = "articleId") Long articleId) {
         articleService.deleteArticle(articleId);
+    }
+
+    @GetMapping
+    public ArticlesResponse getArticles(@RequestParam(name = "boardId") Long boardId,
+                                        @RequestParam(name = "page", defaultValue = "30") Long page,
+                                        @RequestParam(name = "pageSize", defaultValue = "1") Long pageSize) {
+        ArticleResults articles = articleService.getArticles(boardId, page, pageSize);
+        return ArticlesResponse.of(articles.results(), articles.articleCount());
     }
 }

--- a/service/article/src/main/java/article/controller/ArticleController.java
+++ b/service/article/src/main/java/article/controller/ArticleController.java
@@ -6,7 +6,6 @@ import article.controller.dto.response.ArticleResponse;
 import article.controller.dto.response.ArticlesResponse;
 import article.service.dto.result.ArticleResults;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.repository.query.Param;
 import org.springframework.web.bind.annotation.*;
 import article.service.ArticleService;
 import article.service.dto.result.ArticleResult;

--- a/service/article/src/main/java/article/controller/dto/response/ArticlesResponse.java
+++ b/service/article/src/main/java/article/controller/dto/response/ArticlesResponse.java
@@ -1,0 +1,15 @@
+package article.controller.dto.response;
+
+import article.service.dto.result.ArticleResult;
+
+import java.util.List;
+
+public record ArticlesResponse(List<ArticleResponse> articles, Long articleCount) {
+
+    public static ArticlesResponse of(List<ArticleResult> results, Long articleCount) {
+        List<ArticleResponse> articles = results.stream()
+                .map(ArticleResponse::from)
+                .toList();
+        return new ArticlesResponse(articles, articleCount);
+    }
+}

--- a/service/article/src/main/java/article/init/ArticleInit.java
+++ b/service/article/src/main/java/article/init/ArticleInit.java
@@ -27,7 +27,7 @@ public class ArticleInit {
 
     Snowflake snowflake = new Snowflake();
 
-    @PostConstruct
+    //@PostConstruct
     void init() throws InterruptedException {
         CountDownLatch latch = new CountDownLatch(EXECUTE_SIZE);
         ExecutorService executor = Executors.newFixedThreadPool(10);
@@ -46,7 +46,7 @@ public class ArticleInit {
         executor.shutdown();
     }
 
-    @PreDestroy
+    //@PreDestroy
     void destroy() {
         transactionTemplate.execute(status -> {
             articleRepository.deleteAll();

--- a/service/article/src/main/java/article/repository/ArticleRepository.java
+++ b/service/article/src/main/java/article/repository/ArticleRepository.java
@@ -2,6 +2,31 @@ package article.repository;
 
 import article.entity.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ArticleRepository extends JpaRepository<Article, Long> {
+
+    @Query(
+        value = "select article.article_id, article.title, article.content, article.board_id, article.writer_id, " +
+                "article.created_at, article.updated_at " +
+                "from (" +
+                "   select article_id from article " +
+                "   where board_id = :boardId " +
+                "   order by article_id desc " +
+                "   limit :limit offset :offset " +
+                ") t left join article on t.article_id = article.article_id ",
+        nativeQuery = true
+    )
+    List<Article> findAll(@Param("boardId") Long boardId, @Param("offset") Long offset, @Param("limit") Long limit);
+
+    @Query(
+        value = "select count(article_id) from (" +
+                "   select article_id from article where board_id = :boardId limit :limit" +
+                ") t",
+        nativeQuery = true
+    )
+    Long countArticles(@Param("boardId") Long boardId, @Param("limit") Long limit);
 }

--- a/service/article/src/main/java/article/service/ArticleService.java
+++ b/service/article/src/main/java/article/service/ArticleService.java
@@ -4,6 +4,8 @@ import article.controller.dto.request.ArticleCreateRequest;
 import article.controller.dto.request.ArticleUpdateRequest;
 import article.entity.Article;
 import article.service.dto.command.ArticleCreateCommand;
+import article.service.dto.result.ArticleResults;
+import article.util.PageLimitCalculator;
 import exception.BoardException;
 import key.Snowflake;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +14,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import article.repository.ArticleRepository;
 import article.service.dto.result.ArticleResult;
+
+import java.util.List;
 
 import static exception.ErrorCode.ARTICLE_NOT_FOUND;
 
@@ -48,5 +52,19 @@ public class ArticleService {
     @Transactional
     public void deleteArticle(Long articleId) {
         articleRepository.deleteById(articleId);
+    }
+
+    public ArticleResults getArticles(Long boardId, Long page, Long pageSize) {
+        List<Article> articles = articleRepository
+                                .findAll(boardId, (page - 1) * pageSize, pageSize)
+                                .stream().toList();
+        Long articleCount = articleRepository
+                                .countArticles(boardId, PageLimitCalculator.calculatePageLimit(page, pageSize, 30L));
+
+        List<ArticleResult> results = articles
+                                .stream()
+                                .map(ArticleResult::from)
+                                .toList();
+        return ArticleResults.of(results, articleCount);
     }
 }

--- a/service/article/src/main/java/article/service/ArticleService.java
+++ b/service/article/src/main/java/article/service/ArticleService.java
@@ -23,6 +23,8 @@ import static exception.ErrorCode.ARTICLE_NOT_FOUND;
 @RequiredArgsConstructor
 public class ArticleService {
 
+    private static final Long MOVABLE_PAGE_COUNT = 10L;
+
     private Snowflake snowflake = new Snowflake();
 
     private final ArticleMapper articleMapper;
@@ -59,7 +61,7 @@ public class ArticleService {
                                 .findAll(boardId, (page - 1) * pageSize, pageSize)
                                 .stream().toList();
         Long articleCount = articleRepository
-                                .countArticles(boardId, PageLimitCalculator.calculatePageLimit(page, pageSize, 30L));
+                                .countArticles(boardId, PageLimitCalculator.calculatePageLimit(page, pageSize, MOVABLE_PAGE_COUNT));
 
         List<ArticleResult> results = articles
                                 .stream()

--- a/service/article/src/main/java/article/service/dto/result/ArticleResults.java
+++ b/service/article/src/main/java/article/service/dto/result/ArticleResults.java
@@ -1,0 +1,13 @@
+package article.service.dto.result;
+
+import java.util.List;
+
+public record ArticleResults(
+        List<ArticleResult> results,
+        Long articleCount
+) {
+
+    public static ArticleResults of(List<ArticleResult> results, Long articleCount) {
+        return new ArticleResults(results, articleCount);
+    }
+}

--- a/service/article/src/main/java/article/util/PageLimitCalculator.java
+++ b/service/article/src/main/java/article/util/PageLimitCalculator.java
@@ -1,0 +1,12 @@
+package article.util;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class PageLimitCalculator {
+
+    public static Long calculatePageLimit(Long page, Long pageSize, Long movablePageCount) {
+        return (((page - 1) / movablePageCount) + 1) * pageSize * movablePageCount + 1;
+    }
+}

--- a/service/article/src/main/resources/application.yml
+++ b/service/article/src/main/resources/application.yml
@@ -6,7 +6,7 @@ spring:
     password: root
   jpa:
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     show-sql: true
     properties:
       hibernate:


### PR DESCRIPTION
- Updated `ddl-auto` to `update` in `application.yml` for schema management.
- Added pagination support to `ArticleController` with `getArticles` endpoint.
- Introduced `ArticleRepository` queries for fetching paginated articles and their counts.
- Created `PageLimitCalculator` utility for page limit calculations.
- Added `ArticleResults` and `ArticlesResponse` for structuring paginated results.
- Commented out `PostConstruct` and `PreDestroy` methods in `ArticleInit`.